### PR TITLE
make LogTable always signed char

### DIFF
--- a/src/component_types/base_packed_component.h
+++ b/src/component_types/base_packed_component.h
@@ -119,7 +119,7 @@ public:
   static unsigned log2(unsigned v){
          // taken from
          // http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogLookup
-         static const char LogTable256[256] =
+         static const signed char LogTable256[256] =
          {
          #define LT(n) n, n, n, n, n, n, n, n, n, n, n, n, n, n, n, n
              -1, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,


### PR DESCRIPTION
`char` is `signed` by default on x86 but `unsigned` on some ARM platforms and the table needs to contain -1. This leads to errors like this:
```
src/component_types/base_packed_component.h: In static member function ‘static unsigned int BasePackedComponent::log2(unsigned int)’:
src/component_types/base_packed_component.h:128:10: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]
```

This was discovered when building GANAK for julia (Yggdrasil) at https://github.com/JuliaPackaging/Yggdrasil/pull/6393 for the following platforms:
```
aarch64-apple-darwin aarch64-linux-gnu aarch64-linux-musl armv6l-linux-gnueabihf armv6l-linux-musleabihf armv7l-linux-gnueabihf armv7l-linux-musleabihf i686-linux-gnu i686-linux-musl powerpc64le-linux-gnu x86_64-apple-darwin x86_64-linux-gnu x86_64-linux-musl
```
Two more minor fixes that were necessary will follow in separate PRs.

cc: @lkastner