### PR TITLE
readme: fix cmake flag for PCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cp ganak ../bin/
 
 ### Compiling for Mac OS
 
-Simiar to Linux, but you must pass `cmake -DNOPCC=ON ...` to cmake 
+Simiar to Linux, but you must pass `cmake -DDOPCC=OFF ...` to cmake
 
 ## Usage
 You can use the run_ganak.sh script in scripts directory to run ganak. A simple invocation looks as follows:


### PR DESCRIPTION
The flag in the CMake file is `DOPCC` but the README claimed `NOPCC` (with inverse effect).

cc: @lkastner