### PR TITLE
linker: add all required libs when linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,6 @@ add_executable (ganak-bin
 
 target_link_libraries (ganak-bin
 ganak
-${LIB}
 ${GMP_LIB} ${GMPXX_LIB}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ SET(SOURCES
 SET(LIB	clhash component_types)
 
 ADD_LIBRARY(ganak ${SOURCES} ${LIB})
-target_link_libraries (ganak ${LIB})
+target_link_libraries (ganak ${LIB} ${GMP_LIB} ${GMPXX_LIB})
 
 if (NOT WIN32)
     set_target_properties(ganak PROPERTIES
@@ -65,6 +65,7 @@ add_executable (ganak-bin
 
 target_link_libraries (ganak-bin
 ganak
+${LIB}
 ${GMP_LIB} ${GMPXX_LIB}
 )
 


### PR DESCRIPTION
Otherwise this fails with many undefined symbols errors on platforms that don't use allow-undefined by default (e.g. macOS).

For example this for the library:
```
[20:06:30] /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang++ --sysroot=/opt/aarch64-apple-darwin20/aarch64-apple-darwin20/sys-root  -Wall -Wextra -Wunused -Wsign-compare -fno-omit-frame-pointer -Wtype-limits -Wuninitialized -Wno-deprecated -Wstrict-aliasing -Wpointer-arith -Wheader-guard -Wpointer-arith -Wformat-nonliteral -Winit-self -Wparentheses -Wunreachable-code -ggdb3 -O2 -g  -mmacosx-version-min=11.0 -dynamiclib -Wl,-headerpad_max_install_names  -O2 -compatibility_version 1.0.0 -current_version 1.0.0 -o libganak.1.0.dylib -install_name @rpath/libganak.1.0.dylib CMakeFiles/ganak.dir/alt_component_analyzer.cpp.o CMakeFiles/ganak.dir/component_analyzer.cpp.o CMakeFiles/ganak.dir/component_cache.cpp.o CMakeFiles/ganak.dir/component_management.cpp.o CMakeFiles/ganak.dir/instance.cpp.o CMakeFiles/ganak.dir/new_component_analyzer.cpp.o CMakeFiles/ganak.dir/solver.cpp.o CMakeFiles/ganak.dir/statistics.cpp.o CMakeFiles/ganak.dir/GitSHA1.cpp.o  clhash/libclhash.dylib component_types/libcomponent_types.dylib          
[20:06:30] Undefined symbols for architecture arm64:
[20:06:30]   "___gmp_get_memory_functions", referenced from:
[20:06:30]       __ZNK10__gmp_exprIA1_12__mpz_structS1_E7get_strEi in statistics.cpp.o
[20:06:30]       __ZN19__gmp_alloc_cstringD2Ev in statistics.cpp.o
...
```

I also did get some missing symbols for linking the binary which is why I added `LIB` there but I cannot reproduce this anymore right now.

cc: @lkastner