### PR TITLE
use flakes in the relevant packages instead of defining all the builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,626 @@
 {
   "nodes": {
+    "approxmc": {
+      "inputs": {
+        "arjun": "arjun",
+        "cryptominisat": "cryptominisat_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "sbva": "sbva"
+      },
+      "locked": {
+        "lastModified": 1741819396,
+        "narHash": "sha256-o69mVfckrx2WjF9/O1LLfJlcH/BbCKSANCisABL5898=",
+        "owner": "itepastra",
+        "repo": "approxmc",
+        "rev": "b428ad23db644ce9ffd753ef8de69ad9332c97ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "approxmc",
+        "type": "github"
+      }
+    },
+    "arjun": {
+      "inputs": {
+        "cadiback": "cadiback",
+        "cadical": "cadical_2",
+        "cryptominisat": "cryptominisat",
+        "nixpkgs": [
+          "approxmc",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741816476,
+        "narHash": "sha256-uONfMNbj/0VFErH3SlmOoIwjs5Gd/qquPJsq49JUuho=",
+        "owner": "itepastra",
+        "repo": "arjun",
+        "rev": "67c2a90760c43d5ef1af2b9844f4e488722c5f3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "arjun",
+        "type": "github"
+      }
+    },
+    "arjun_2": {
+      "inputs": {
+        "cadiback": "cadiback_4",
+        "cadical": "cadical_8",
+        "cryptominisat": "cryptominisat_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "sbva": "sbva_2"
+      },
+      "locked": {
+        "lastModified": 1741818506,
+        "narHash": "sha256-bXvLs5B0//hYCMjf9Q9eP6ohAY78QNYBTwFJYqAhn5I=",
+        "owner": "itepastra",
+        "repo": "arjun",
+        "rev": "b53b04b39d28953895d646b1148fa026a9a22682",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "arjun",
+        "type": "github"
+      }
+    },
+    "breakid": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741818960,
+        "narHash": "sha256-DoQb7m27EE9FpDB7JeZlmFOdizXt45SE+E5VWfORL1I=",
+        "owner": "itepastra",
+        "repo": "breakid",
+        "rev": "48830178463dc0da8a5e4429decc7b720a25cb5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "breakid",
+        "type": "github"
+      }
+    },
+    "cadiback": {
+      "inputs": {
+        "cadical": "cadical",
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741797581,
+        "narHash": "sha256-74vgCcCQafIZYstYnDwnGwoGK37ZLKm/FyXoLirLL2U=",
+        "owner": "itepastra",
+        "repo": "cadiback",
+        "rev": "75a0ea4a49c4b6293614a992bc2a82759792a962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadiback",
+        "type": "github"
+      }
+    },
+    "cadiback_2": {
+      "inputs": {
+        "cadical": "cadical_3",
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741797581,
+        "narHash": "sha256-74vgCcCQafIZYstYnDwnGwoGK37ZLKm/FyXoLirLL2U=",
+        "owner": "itepastra",
+        "repo": "cadiback",
+        "rev": "75a0ea4a49c4b6293614a992bc2a82759792a962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadiback",
+        "type": "github"
+      }
+    },
+    "cadiback_3": {
+      "inputs": {
+        "cadical": "cadical_5",
+        "nixpkgs": [
+          "approxmc",
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741797581,
+        "narHash": "sha256-74vgCcCQafIZYstYnDwnGwoGK37ZLKm/FyXoLirLL2U=",
+        "owner": "itepastra",
+        "repo": "cadiback",
+        "rev": "75a0ea4a49c4b6293614a992bc2a82759792a962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadiback",
+        "type": "github"
+      }
+    },
+    "cadiback_4": {
+      "inputs": {
+        "cadical": "cadical_7",
+        "nixpkgs": [
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741797581,
+        "narHash": "sha256-74vgCcCQafIZYstYnDwnGwoGK37ZLKm/FyXoLirLL2U=",
+        "owner": "itepastra",
+        "repo": "cadiback",
+        "rev": "75a0ea4a49c4b6293614a992bc2a82759792a962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadiback",
+        "type": "github"
+      }
+    },
+    "cadiback_5": {
+      "inputs": {
+        "cadical": "cadical_9",
+        "nixpkgs": [
+          "arjun",
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741797581,
+        "narHash": "sha256-74vgCcCQafIZYstYnDwnGwoGK37ZLKm/FyXoLirLL2U=",
+        "owner": "itepastra",
+        "repo": "cadiback",
+        "rev": "75a0ea4a49c4b6293614a992bc2a82759792a962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadiback",
+        "type": "github"
+      }
+    },
+    "cadiback_6": {
+      "inputs": {
+        "cadical": "cadical_11",
+        "nixpkgs": [
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741797581,
+        "narHash": "sha256-74vgCcCQafIZYstYnDwnGwoGK37ZLKm/FyXoLirLL2U=",
+        "owner": "itepastra",
+        "repo": "cadiback",
+        "rev": "75a0ea4a49c4b6293614a992bc2a82759792a962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadiback",
+        "type": "github"
+      }
+    },
+    "cadical": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "cadiback",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_10": {
+      "inputs": {
+        "nixpkgs": [
+          "arjun",
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_11": {
+      "inputs": {
+        "nixpkgs": [
+          "cryptominisat",
+          "cadiback",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_12": {
+      "inputs": {
+        "nixpkgs": [
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_2": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_3": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "cryptominisat",
+          "cadiback",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_4": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_5": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "cryptominisat",
+          "cadiback",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_6": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "cryptominisat",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_7": {
+      "inputs": {
+        "nixpkgs": [
+          "arjun",
+          "cadiback",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_8": {
+      "inputs": {
+        "nixpkgs": [
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cadical_9": {
+      "inputs": {
+        "nixpkgs": [
+          "arjun",
+          "cryptominisat",
+          "cadiback",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741795024,
+        "narHash": "sha256-7cHubV0xHcIixU6JMZ0s5cxaJ1wJSG+CmPxUJ4G2n+0=",
+        "owner": "itepastra",
+        "repo": "cadical",
+        "rev": "13b5ddf5713933648ddc23d2723854de3f40a589",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cadical",
+        "type": "github"
+      }
+    },
+    "cryptominisat": {
+      "inputs": {
+        "cadiback": "cadiback_2",
+        "cadical": "cadical_4",
+        "nixpkgs": [
+          "approxmc",
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741798258,
+        "narHash": "sha256-C9SFm6EPlFY3ozl9dOET9tnk07W14YQ8SRtec89QPwc=",
+        "owner": "itepastra",
+        "repo": "cryptominisat",
+        "rev": "0087864e0c9a4fe54e48f1de8ff14d9087de5231",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cryptominisat",
+        "type": "github"
+      }
+    },
+    "cryptominisat_2": {
+      "inputs": {
+        "cadiback": "cadiback_3",
+        "cadical": "cadical_6",
+        "nixpkgs": [
+          "approxmc",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741798258,
+        "narHash": "sha256-C9SFm6EPlFY3ozl9dOET9tnk07W14YQ8SRtec89QPwc=",
+        "owner": "itepastra",
+        "repo": "cryptominisat",
+        "rev": "0087864e0c9a4fe54e48f1de8ff14d9087de5231",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cryptominisat",
+        "type": "github"
+      }
+    },
+    "cryptominisat_3": {
+      "inputs": {
+        "cadiback": "cadiback_5",
+        "cadical": "cadical_10",
+        "nixpkgs": [
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741798258,
+        "narHash": "sha256-C9SFm6EPlFY3ozl9dOET9tnk07W14YQ8SRtec89QPwc=",
+        "owner": "itepastra",
+        "repo": "cryptominisat",
+        "rev": "0087864e0c9a4fe54e48f1de8ff14d9087de5231",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cryptominisat",
+        "type": "github"
+      }
+    },
+    "cryptominisat_4": {
+      "inputs": {
+        "cadiback": "cadiback_6",
+        "cadical": "cadical_12",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741798258,
+        "narHash": "sha256-C9SFm6EPlFY3ozl9dOET9tnk07W14YQ8SRtec89QPwc=",
+        "owner": "itepastra",
+        "repo": "cryptominisat",
+        "rev": "0087864e0c9a4fe54e48f1de8ff14d9087de5231",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "cryptominisat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740303746,
-        "narHash": "sha256-XcdiWLEhjJkMxDLKQJ0CCivmYYCvA5MDxu9pMybM5kM=",
+        "lastModified": 1741708242,
+        "narHash": "sha256-cNRqdQD4sZpN7JLqxVOze4+WsWTmv2DGH0wNCOVwrWc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d068ae5c6516b2d04562de50a58c682540de9bf",
+        "rev": "b62d2a95c72fb068aecd374a7262b37ed92df82b",
         "type": "github"
       },
       "original": {
@@ -18,7 +632,77 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "approxmc": "approxmc",
+        "arjun": "arjun_2",
+        "breakid": "breakid",
+        "cryptominisat": "cryptominisat_4",
+        "nixpkgs": "nixpkgs",
+        "sbva": "sbva_3"
+      }
+    },
+    "sbva": {
+      "inputs": {
+        "nixpkgs": [
+          "approxmc",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741818348,
+        "narHash": "sha256-uIZjMl4/p8XNPeyltfM82vCMdXTbLgowdnBFEa+/93E=",
+        "owner": "itepastra",
+        "repo": "sbva",
+        "rev": "0bf98e8f2a3fbfd84f4e9c76780c3cdc7428aa59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "sbva",
+        "type": "github"
+      }
+    },
+    "sbva_2": {
+      "inputs": {
+        "nixpkgs": [
+          "arjun",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741818348,
+        "narHash": "sha256-uIZjMl4/p8XNPeyltfM82vCMdXTbLgowdnBFEa+/93E=",
+        "owner": "itepastra",
+        "repo": "sbva",
+        "rev": "0bf98e8f2a3fbfd84f4e9c76780c3cdc7428aa59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "sbva",
+        "type": "github"
+      }
+    },
+    "sbva_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741818348,
+        "narHash": "sha256-uIZjMl4/p8XNPeyltfM82vCMdXTbLgowdnBFEa+/93E=",
+        "owner": "itepastra",
+        "repo": "sbva",
+        "rev": "0bf98e8f2a3fbfd84f4e9c76780c3cdc7428aa59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "itepastra",
+        "ref": "add-flake",
+        "repo": "sbva",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,37 @@
   description = "A Scalable Probabilistic Exact Model Counter";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    arjun = {
+      url = "github:itepastra/arjun/add-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    cryptominisat = {
+      url = "github:itepastra/cryptominisat/add-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    sbva = {
+      url = "github:itepastra/sbva/add-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    approxmc = {
+      url = "github:itepastra/approxmc/add-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    breakid = {
+      url = "github:itepastra/breakid/add-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
       self,
       nixpkgs,
+      arjun,
+      approxmc,
+      breakid,
+      cryptominisat,
+      sbva,
     }:
     let
       inherit (nixpkgs) lib;
@@ -15,267 +40,6 @@
       forAllSystems = lib.genAttrs systems;
       nixpkgsFor = forAllSystems (system: nixpkgs.legacyPackages.${system});
 
-      cadical-package =
-        {
-          stdenv,
-          fetchFromGitHub,
-          lsd,
-        }:
-        stdenv.mkDerivation {
-          name = "cadical";
-          src = fetchFromGitHub {
-            owner = "meelgroup";
-            repo = "cadical";
-            rev = "45850b35836122622a983e637251299cc16f3161";
-            name = "cadical";
-            hash = "sha256-ugAudDgw91DeR90zQR5RlCKoLv/hDdv03oa1v3lG1nY=";
-          };
-
-          configurePhase = ''./configure --competition'';
-
-          installPhase = ''
-            mkdir -p $out/lib
-            cp -r . $out
-            cp build/libcadical.a $out/lib
-            mkdir -p $out/include
-            cp src/*.hpp $out/include
-          '';
-        };
-      cadiback-package =
-        {
-          stdenv,
-          fetchFromGitHub,
-          git,
-          cadical,
-        }:
-        stdenv.mkDerivation {
-          name = "cadiback";
-          src = fetchFromGitHub {
-            owner = "meelgroup";
-            repo = "cadiback";
-            rev = "860b1df7f7b5e966b423163d89ec5a972e09ae67";
-            name = "cadiback";
-            hash = "sha256-sKKIOWQjW2c5Duz/jf00ggwXMlQ9KL7mVL7val47Cng=";
-            leaveDotGit = true;
-          };
-
-          nativeBuildInputs = [ git ];
-          buildInputs = [ cadical ];
-
-          patchPhase = ''
-            substituteInPlace makefile.in \
-              --replace-fail "/usr/" "$out/" \
-              --replace-fail "../cadical" "${cadical}"
-          '';
-          configurePhase = ''
-            export CADICAL=${cadical}
-            ./configure
-          '';
-
-          preInstall = ''
-            mkdir -p $out/lib
-            mkdir -p $out/include
-          '';
-        };
-      ensmallen-package =
-        {
-          stdenv,
-          cmake,
-          fetchzip,
-          armadillo,
-        }:
-        stdenv.mkDerivation {
-          name = "ensmallen";
-          src = fetchzip {
-            url = "https://ensmallen.org/files/ensmallen-2.21.1.tar.gz";
-            hash = "sha256-6LZooaR0rmqWgEm0AxmWoVPuIahjOfwSFu5cssc7LA8=";
-          };
-          nativeBuildInputs = [ cmake ];
-          buildInputs = [ armadillo ];
-        };
-      mlpack-package =
-        {
-          stdenv,
-          fetchFromGitHub,
-          lsd,
-          cmake,
-          armadillo,
-          ensmallen,
-          cereal,
-          pkg-config,
-        }:
-        stdenv.mkDerivation {
-          name = "mlpack";
-          src = fetchFromGitHub {
-            "owner" = "mlpack";
-            "repo" = "mlpack";
-            "rev" = "4.4.0";
-            "hash" = "sha256-EPz8qPTUAldS+k5/qkZf8EKXKjnxElfJxlTEMLPhTQE=";
-          };
-          nativeBuildInputs = [
-            pkg-config
-            cmake
-            armadillo
-          ];
-          buildInputs = [
-            ensmallen
-            cereal
-          ];
-        };
-      cryptominisat-package =
-        {
-          stdenv,
-          fetchFromGitHub,
-          cmake,
-          cadiback,
-          cadical,
-          pkg-config,
-          gmp,
-        }:
-        stdenv.mkDerivation {
-          name = "cryptominisat";
-          src = fetchFromGitHub {
-            owner = "msoos";
-            repo = "cryptominisat";
-            fetchSubmodules = true;
-            rev = "7b58aa32cc7ee8416ebb09aad0f4e9c652f38e21";
-            hash = "sha256-m3WtMY83qJRoL2+cG1L+EZVL7t9ckSaMW+DMWxUsToU=";
-          };
-
-          patchPhase = ''
-            substituteInPlace src/backbone.cpp \
-              --replace-fail "../cadiback/cadiback.h" "${cadiback}/include/cadiback.h"
-          '';
-
-          nativeBuildInputs = [
-            cmake
-            pkg-config
-          ];
-          buildInputs = [
-            cadiback
-            cadical
-            gmp
-          ];
-        };
-      arjun-package =
-        {
-          stdenv,
-          fetchFromGitHub,
-          cmake,
-          sbva,
-          zlib,
-          gmp,
-          cadiback,
-          pkg-config,
-          mlpack,
-          armadillo,
-          cereal,
-          ensmallen,
-          cadical,
-          cryptominisat,
-        }:
-        stdenv.mkDerivation {
-          name = "arjun";
-          src = fetchFromGitHub {
-            owner = "meelgroup";
-            repo = "arjun";
-            rev = "b05b4cce46b5c6fca77b8829c0ab0d49b9a70159";
-            hash = "sha256-qQT16wNiRoNwpTpIxg80+SjGUhVXvuWYXFaS+kq2ezc=";
-          };
-          nativeBuildInputs = [
-            pkg-config
-            cmake
-          ];
-          buildInputs = [
-            zlib
-            sbva
-            gmp
-            cadiback
-            mlpack
-            armadillo
-            cereal
-            ensmallen
-            cadical
-            cryptominisat
-          ];
-
-        };
-      sbva-package =
-        {
-          stdenv,
-          eigen,
-          fetchFromGitHub,
-          cmake,
-          autoPatchelfHook,
-        }:
-        stdenv.mkDerivation {
-          name = "sbva";
-          src = fetchFromGitHub {
-            owner = "meelgroup";
-            repo = "SBVA";
-            rev = "5912435affe8c77ecf364093cea29e0fc5c1b5cb";
-            hash = "sha256-BoR14FBH3eCPYio6l6d+oQp3/hu4U7t1STb9NgSWJ2M=";
-          };
-          nativeBuildInputs = [
-            cmake
-            autoPatchelfHook
-          ];
-          buildInputs = [ eigen ];
-        };
-      breakid-package =
-        {
-          stdenv,
-          cmake,
-          autoPatchelfHook,
-          fetchFromGitHub,
-        }:
-        stdenv.mkDerivation {
-          name = "breakid";
-          src = fetchFromGitHub {
-            owner = "meelgroup";
-            repo = "breakid";
-            rev = "f90eff992342024640f9d539c1e68ef924b22994";
-            hash = "sha256-hxVvfOfPQxZ6RUYv6BWWohEbvoPfjWIa+UNtkOuvS1Q=";
-          };
-          nativeBuildInputs = [
-            cmake
-            autoPatchelfHook
-          ];
-          postInstall = ''mv $out/include/breakid/* $out/include/'';
-        };
-      approxmc-package =
-        {
-          stdenv,
-          cmake,
-          autoPatchelfHook,
-          fetchFromGitHub,
-          gmp,
-          zlib,
-          cryptominisat,
-          arjun,
-          sbva,
-        }:
-        stdenv.mkDerivation {
-          name = "approxmc";
-          src = fetchFromGitHub {
-            owner = "meelgroup";
-            repo = "approxmc";
-            rev = "e630146ccee72b939e984874a1ecceeb9c4c4ca3";
-            hash = "sha256-Gi5wAuACucIx2E4oLv5P+CFVSQRecdA/dK4Wr3xghWI=";
-          };
-          nativeBuildInputs = [
-            cmake
-            autoPatchelfHook
-          ];
-          buildInputs = [
-            gmp
-            zlib
-            cryptominisat
-            arjun
-            sbva
-          ];
-          postInstall = ''mv $out/include/approxmc/approxmc.h $out/include/approxmc.h'';
-        };
       ganak-package =
         {
           stdenv,
@@ -339,49 +103,16 @@
       packages = forAllSystems (
         system:
         let
-          cadical = nixpkgsFor.${system}.callPackage cadical-package { };
-          cadiback = nixpkgsFor.${system}.callPackage cadiback-package { inherit cadical; };
-          cryptominisat = nixpkgsFor.${system}.callPackage cryptominisat-package {
-            inherit cadical cadiback;
-          };
-          arjun = nixpkgsFor.${system}.callPackage arjun-package {
-            inherit
-              sbva
-              cadiback
-              cadical
-              mlpack
-              cryptominisat
-              ensmallen
-              ;
-          };
-          sbva = nixpkgsFor.${system}.callPackage sbva-package { };
-          breakid = nixpkgsFor.${system}.callPackage breakid-package { };
-          ensmallen = nixpkgsFor.${system}.callPackage ensmallen-package { };
-          mlpack = nixpkgsFor.${system}.callPackage mlpack-package { inherit ensmallen; };
-          approxmc = nixpkgsFor.${system}.callPackage approxmc-package { inherit arjun sbva cryptominisat; };
           ganak = nixpkgsFor.${system}.callPackage ganak-package {
-            inherit
-              arjun
-              sbva
-              breakid
-              approxmc
-              cryptominisat
-              ;
+            cryptominisat = cryptominisat.packages.${system}.cryptominisat;
+            arjun = arjun.packages.${system}.arjun;
+            sbva = sbva.packages.${system}.sbva;
+            breakid = breakid.packages.${system}.breakid;
+            approxmc = approxmc.packages.${system}.approxmc;
           };
         in
         {
-          inherit
-            cadical
-            arjun
-            ganak
-            sbva
-            breakid
-            approxmc
-            cadiback
-            ensmallen
-            mlpack
-            cryptominisat
-            ;
+          inherit ganak;
           default = ganak;
         }
       );


### PR DESCRIPTION
Update the nix flake to have the various packages be built in their respective repositories. 
Allows for updating using `nix flake update` which helps keep every version aligned.
The relevant PR's in the other repositories are
- https://github.com/meelgroup/arjun/pull/14
- https://github.com/meelgroup/approxmc/pull/57
- https://github.com/meelgroup/SBVA/pull/1
- https://github.com/msoos/cryptominisat/pull/780
- https://github.com/meelgroup/cadiback/pull/2
- https://github.com/meelgroup/cadical/pull/1
- https://github.com/meelgroup/breakid/pull/3
Currently the flake defines my fork branches as the inputs (also in the sub-PR's), these should be changed to the relevant
branches in the repositories themselves and then the lock file should be regenerated using `nix flake update`.