### PR TITLE
Allow tuning td max var/edge and density cutoffs

### DIFF
--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -328,11 +328,11 @@ void Counter::td_decompose() {
     verb_print(1, "[td] Too many edges, " << primal.numEdges() << " skipping TD");
     return;
   }
-  if (density > 0.3) {
+  if (density > conf.td_max_density) {
     verb_print(1, "[td] Density is too high, " << density << " skipping TD");
     return;
   }
-  if (edge_var_ratio > 30) {
+  if (edge_var_ratio > conf.td_max_edge_var_ratio) {
     verb_print(1, "[td] edge/var ratio is too high (" << edge_var_ratio  << "), not running TD");
     return;
   }

--- a/src/counter_config.hpp
+++ b/src/counter_config.hpp
@@ -90,6 +90,8 @@ struct CounterConfiguration {
   int do_td_contract = 1;
   int td_limit = 100000;
   int do_td_use_opt_indep = 1;
+  double td_max_density = 0.3;
+  int td_max_edge_var_ratio = 30;
 
   int do_use_sat_solver = 1;
   int sat_restart_mult = 300;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,6 +180,8 @@ void add_ganak_options()
     myopt("--tdcontract", conf.do_td_contract, atoi, "TD contract over opt indep set");
     myopt("--tdlimit", conf.td_limit, atoi, "If TD is over this, reduce weight to 0.1");
     myopt("--tdoptindep", conf.do_td_use_opt_indep, atoi, "Use opt indep for TD computation");
+    myopt("--tdmaxdensity", conf.td_max_density, atof, "Max density for TD computation");
+    myopt("--tdmaxedgeratio", conf.td_max_edge_var_ratio, atoi, "Max edge to var ratio for TD computation");
 
     // Clause DB options
     myopt("--rdbclstarget", conf.rdb_cls_target, atoi, "RDB clauses target size (added to this are LBD 3 or lower)");


### PR DESCRIPTION
Adding:

```
  --tdmaxdensity          Max density for TD computation [nargs=0..1] [default: 0.3]
  --tdmaxedgeratio        Max edge to var ratio for TD computation [nargs=0..1] [default: 30]
```