### PR TITLE
Last used time can overflow

### DIFF
--- a/src/comp_types/base_comp.hpp
+++ b/src/comp_types/base_comp.hpp
@@ -87,4 +87,5 @@ protected:
   uint64_t delete_permitted:1 = false;
 };
 
+static_assert(sizeof(BaseComp) <= 2*sizeof(uint64_t), "BaseComp is not packed");
 }


### PR DESCRIPTION
OOops, and it did, on a long-running program:

```
c o [td] centroid bag size 42  #npvars 42                                                                                                                                                    ganak: /home/soos/development/sat_solvers/ganak/src/comp_types/base_comp.hpp:61: void GanakInt::BaseComp::avg_last_used_time(uint32_t, uint32_t): Assertion `time >= last_used_time_' failed.
[1]    1295419 IOT instruction (core dumped)  ./ganak --tduseadj 0 --tdoptindep 0 --arjuniter1 1 --mode 6
```