### PR TITLE
Some cleanup and fixes

### DIFF
--- a/src/clauseallocator.cpp
+++ b/src/clauseallocator.cpp
@@ -47,7 +47,7 @@ void* ClauseAllocator::alloc_enough(uint32_t num_lits) {
 
   if (size + needed > capacity) {
     //Grow by default, but don't go under or over the limits
-    uint64_t newcapacity = capacity * ALLOC_GROW_MULT;
+    uint64_t newcapacity = (double)capacity * ALLOC_GROW_MULT;
     newcapacity = std::max<size_t>(newcapacity, MIN_LIST_SIZE);
     while (newcapacity < size+needed) {
         newcapacity *= ALLOC_GROW_MULT;

--- a/src/comp_analyzer.hpp
+++ b/src/comp_analyzer.hpp
@@ -120,7 +120,6 @@ public:
         Counter* _counter);
 
   auto freq_score_of(uint32_t v) const { return var_freq_scores[v]; }
-  void un_bump_score(uint32_t v) { var_freq_scores[v] --; }
   inline void bump_freq_score(uint32_t v) { var_freq_scores[v] ++; }
   const CompArchetype& current_archetype() const { return archetype; }
 

--- a/src/comp_cache.hpp
+++ b/src/comp_cache.hpp
@@ -164,9 +164,9 @@ private:
       double vm_after;
       auto used_after = mem_used(vm_after);
       verb_print(2,
-        "table resize -- used before: " << used_before/(double)(1024*1024)
-        << " vm used before: " << vm_before/(double)(1024*1024)
-        << " used after: " << used_after/(double)(1024*1024)
+        "table resize -- used before: " << (double)used_before/(double)(1024*1024)
+        << " vm used before: " << (double)vm_before/(double)(1024*1024)
+        << " used after: " << (double)used_after/(double)(1024*1024)
         << " vm used after: " << vm_after/(double)(1024*1024)
         << " total T: " << cpu_time());
     }
@@ -251,14 +251,14 @@ CacheEntryID CompCache<T>::add_new_comp(void* c, CacheEntryID super_comp_id) {
       verb_print(3,std::setw(40) << "After enlarge entry_base mem use MB: " <<
         (double)(entry_base.capacity()*sizeof(comp))/(double)(1024*1024));
       verb_print(3,
-        "Before entry enlarge Total process MB : " << dat/(double)(1024*1024)
+        "Before entry enlarge Total process MB : " << (double)dat/(double)(1024*1024)
         << " Total process vm MB: " << vm_dat/(double)(1024*1024));
 
     }
     entry_base.emplace_back(std::move(comp));
     if (at_capacity && conf.verb >= 3) {
       double vm_dat;
-      double dat = mem_used(vm_dat);
+      double dat = (double)mem_used(vm_dat);
       verb_print(3,std::setw(40) << "After enlarge entry_base mem use MB: " <<
         (double)(entry_base.capacity()*sizeof(comp))/(double)(1024*1024));
       verb_print(3,
@@ -512,11 +512,11 @@ void CompCache<T>::debug_mem_data() const {
     for (auto &entry : entry_base)
       if (!entry.is_free()) tot_extra_bytes += entry.extra_bytes();
     cout << std::setw(40) << "c o bignum(+packed comp if used) uses MB "
-      << tot_extra_bytes/(double)(1024*1024) << endl;
+      << (double)tot_extra_bytes/(double)(1024*1024) << endl;
 
     double vm_dat;
     auto dat = mem_used(vm_dat);
-    verb_print(1, "Total process MB : " << dat/(double)(1024*1024)
+    verb_print(1, "Total process MB : " << (double)dat/(double)(1024*1024)
       << " Total process vm MB: " << vm_dat/(double)(1024*1024));
 }
 

--- a/src/comp_cache.hpp
+++ b/src/comp_cache.hpp
@@ -54,7 +54,7 @@ public:
 
     return ret;
   }
-  uint32_t get_extra_bytes(void* c) const override {
+  uint64_t get_extra_bytes(void* c) const override {
     T* comp = reinterpret_cast<T*>(c);
     return comp->extra_bytes();
   }
@@ -98,7 +98,7 @@ public:
   bool find_comp_and_incorporate_cnt(StackLevel &top, const uint32_t nvars, const void* c) override {
     const T& comp = *reinterpret_cast<const T*>(c);
     stats.num_cache_look_ups++;
-    uint32_t table_ofs = comp.get_hashkey() & tbl_size_mask;
+    uint32_t table_ofs = (uint32_t)comp.get_hashkey() & tbl_size_mask;
     CacheEntryID act_id = table[table_ofs];
     if (!act_id) return false;
     while(act_id){
@@ -192,7 +192,7 @@ private:
   }
 
   uint32_t table_pos(CacheEntryID id) const {
-    return entry(id).get_hashkey() & tbl_size_mask;
+    return (uint32_t)entry(id).get_hashkey() & tbl_size_mask;
   }
 
   void add_descendant(CacheEntryID compid, CacheEntryID descendantid) {

--- a/src/comp_cache.hpp
+++ b/src/comp_cache.hpp
@@ -130,7 +130,7 @@ public:
   // store the number in model_count as the model count of CacheEntryID id
   void store_value(const CacheEntryID id, const FF& model_count) override;
 
-  double calc_cutoff() const override;
+  uint64_t calc_cutoff() const override;
   bool delete_some_entries() override;
 
   // delete entries, keeping the descendants tree consistent
@@ -413,8 +413,8 @@ void CompCache<T>::test_descendantstree_consistency() {
 }
 
 template<typename T>
-double CompCache<T>::calc_cutoff() const {
-  vector<uint32_t> scores;
+uint64_t CompCache<T>::calc_cutoff() const {
+  vector<uint64_t> scores;
   // TODO: this score is VERY simplistic, we actually don't touch it at all, ever
   //       just create it and that's it. Not bumped with usage(!)
   for (auto it = entry_base.begin() + 1; it != entry_base.end(); it++)
@@ -431,7 +431,7 @@ double CompCache<T>::calc_cutoff() const {
 template<typename T>
 bool CompCache<T>::delete_some_entries() {
   const auto start_del_time = cpu_time();
-  double cutoff = calc_cutoff();
+  uint64_t cutoff = (uint64_t)calc_cutoff();
   verb_print(1, "Deleting entires. Num entries: " << entry_base.size());
   verb_print(1, "cache_bytes_memory_usage() in MB: " << (stats.cache_bytes_memory_usage())/(1024ULL*1024ULL));
   verb_print(1, "max_cache_size_bytes in MB: " << (stats.max_cache_size_bytes)/(1024ULL*1024ULL));

--- a/src/comp_cache_if.hpp
+++ b/src/comp_cache_if.hpp
@@ -41,7 +41,7 @@ public:
   virtual ~CompCacheIF();
 
   virtual CacheEntryID add_new_comp(void* comp, CacheEntryID super_comp_id) = 0;
-  virtual uint32_t get_extra_bytes(void* comp) const = 0;
+  virtual uint64_t get_extra_bytes(void* comp) const = 0;
   virtual bool find_comp_and_incorporate_cnt(StackLevel &top, const uint32_t nvars, const void* comp) = 0;
   virtual void* create_new_comp(const Comp &comp, uint64_t hash_seed, const BPCSizes& bpc) = 0;
   virtual void free_comp(void* comp) = 0;

--- a/src/comp_cache_if.hpp
+++ b/src/comp_cache_if.hpp
@@ -57,7 +57,7 @@ public:
   virtual uint64_t clean_pollutions_involving(CacheEntryID id) = 0;
   virtual void erase(CacheEntryID id) = 0;
   virtual void store_value(const CacheEntryID id, const FF& model_count) = 0;
-  virtual double calc_cutoff() const = 0;
+  virtual uint64_t calc_cutoff() const = 0;
   virtual bool delete_some_entries() = 0;
   virtual uint64_t unlink_from_tree(CacheEntryID id) = 0;
   virtual uint64_t num_descendants(CacheEntryID id) = 0;

--- a/src/comp_management.cpp
+++ b/src/comp_management.cpp
@@ -39,7 +39,7 @@ void CompManager::remove_cache_pollutions_of_if_exists(const StackLevel &top) {
   assert(top.remaining_comps_ofs() <= comp_stack.size());
   assert(top.super_comp() != 0);
 
-  for (uint32_t u = top.remaining_comps_ofs(); u < comp_stack.size(); u++) {
+  for (uint64_t u = top.remaining_comps_ofs(); u < comp_stack.size(); u++) {
     if (!cache->exists(comp_stack[u]->id())) continue;
     stats.cache_pollutions_removed += cache->clean_pollutions_involving(comp_stack[u]->id());
   }
@@ -54,7 +54,7 @@ void CompManager::remove_cache_pollutions_of(const StackLevel &top) {
   assert(top.super_comp() != 0);
   assert(cache->exists(get_super_comp(top).id()));
 
-  for (uint32_t u = top.remaining_comps_ofs(); u < comp_stack.size(); u++) {
+  for (uint64_t u = top.remaining_comps_ofs(); u < comp_stack.size(); u++) {
     assert(cache->exists(comp_stack[u]->id()));
     stats.cache_pollutions_removed += cache->clean_pollutions_involving(comp_stack[u]->id());
   }
@@ -69,7 +69,7 @@ void CompManager::remove_cache_pollutions_of(const StackLevel &top) {
 // Runs a LOT of the time, like 40%+
 void CompManager::record_remaining_comps_for(StackLevel &top) {
   const Comp& super_comp = get_super_comp(top);
-  const uint32_t new_comps_start_ofs = comp_stack.size();
+  const uint64_t new_comps_start_ofs = comp_stack.size();
 
   // This reinitializes archetype, sets up seen[] or all cls&vars unvisited (if unset), etc.
   // Sets all unknown vars in seen[] and sets all clauses in seen[] to unvisited

--- a/src/comp_management.hpp
+++ b/src/comp_management.hpp
@@ -95,7 +95,7 @@ public:
   // returns false if all comps have been processed
   inline bool find_next_remain_comp_of(StackLevel &top);
   void record_remaining_comps_for(StackLevel &top);
-  inline void sort_comp_stack_range(uint32_t start, uint32_t end);
+  inline void sort_comp_stack_range(uint64_t start, uint64_t end);
   inline double get_alternate_score_comps(uint32_t start, uint32_t end) const;
 
   void remove_cache_pollutions_of_if_exists(const StackLevel &top);
@@ -119,7 +119,7 @@ private:
   CompAnalyzer ana;
 };
 
-inline void CompManager::sort_comp_stack_range(uint32_t start, uint32_t end) {
+inline void CompManager::sort_comp_stack_range(uint64_t start, uint64_t end) {
   debug_print(COLYEL2 "sorting comp stack range");
   assert(start <= end);
   if (start == end) return;

--- a/src/comp_management.hpp
+++ b/src/comp_management.hpp
@@ -59,7 +59,7 @@ public:
   auto& get_cache() const { return cache; }
   const CompAnalyzer& get_ana() const { return ana; }
 
-  void save_count(const uint32_t stack_comp_id, const FF& value) {
+  void save_count(const uint64_t stack_comp_id, const FF& value) {
     debug_print(COLYEL2 << "Store. comp ID: " << stack_comp_id
         << " cache ID: " << comp_stack[stack_comp_id]->id() << " cnt: " << *value);
     cache->store_value(comp_stack[stack_comp_id]->id(), value);
@@ -74,7 +74,7 @@ public:
     assert(comp_stack.size() > lev.super_comp());
     return *comp_stack[lev.super_comp()];
   }
-  uint32_t comp_stack_size() { return comp_stack.size(); }
+  size_t comp_stack_size() { return comp_stack.size(); }
   const Comp* at(const size_t at) const { return comp_stack.at(at); }
   void clean_remain_comps_of(const StackLevel& top) {
     debug_print(COLYEL2 "cleaning (all remaining) comps of var: " << top.var);
@@ -96,7 +96,6 @@ public:
   inline bool find_next_remain_comp_of(StackLevel &top);
   void record_remaining_comps_for(StackLevel &top);
   inline void sort_comp_stack_range(uint64_t start, uint64_t end);
-  inline double get_alternate_score_comps(uint32_t start, uint32_t end) const;
 
   void remove_cache_pollutions_of_if_exists(const StackLevel &top);
   void remove_cache_pollutions_of(const StackLevel &top);
@@ -132,14 +131,6 @@ inline void CompManager::sort_comp_stack_range(uint64_t start, uint64_t end) {
                   < comp_stack[j]->nVars())
         std::swap(comp_stack[i], comp_stack[j]);
     }
-}
-
-inline double CompManager::get_alternate_score_comps(uint32_t start, uint32_t end) const {
-  double score = 1;
-  assert(start <= end);
-  // sort the remaining comps for processing
-  for (uint32_t i = start; i < end; i++) score *= comp_stack[i]->nVars();
-  return score;
 }
 
 inline bool CompManager::find_next_remain_comp_of(StackLevel& top) {

--- a/src/comp_management.hpp
+++ b/src/comp_management.hpp
@@ -125,8 +125,8 @@ inline void CompManager::sort_comp_stack_range(uint64_t start, uint64_t end) {
   // sort the remaining comps for processing
   stats.comp_sorts++;
   stats.comp_sizes+= end - start;
-  for (uint32_t i = start; i < end; i++)
-    for (uint32_t j = i + 1; j < end; j++) {
+  for (uint64_t i = start; i < end; i++)
+    for (uint64_t j = i + 1; j < end; j++) {
       if (comp_stack[i]->nVars()
                   < comp_stack[j]->nVars())
         std::swap(comp_stack[i], comp_stack[j]);

--- a/src/comp_types/base_comp.hpp
+++ b/src/comp_types/base_comp.hpp
@@ -56,7 +56,7 @@ public:
     last_used_time_ = b.last_used_time_;
     delete_permitted = b.delete_permitted;
   }
-  uint32_t last_used_time() const { return last_used_time_; }
+  uint64_t last_used_time() const { return last_used_time_; }
   const FF& model_count() const { return model_count_; }
   uint64_t bignum_bytes() const{
     if (!model_count_) return 0;

--- a/src/comp_types/comp.hpp
+++ b/src/comp_types/comp.hpp
@@ -144,7 +144,7 @@ private:
 
 inline Comp* reserve_comp_space(uint32_t nVars, uint32_t num_clauses) {
   // vars, clauses, and the two sentinels
-  uint32_t bytes_needed = (nVars + num_clauses + 2) * sizeof(uint32_t);
+  uint64_t bytes_needed = (nVars + num_clauses + 2) * sizeof(uint32_t);
   bytes_needed += sizeof(Comp);
   Comp* ptr = (Comp*) malloc (bytes_needed);
   ptr->clear();

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -170,7 +170,7 @@ public:
   FF outer_count();
   uint64_t get_tstamp() const { return tstamp; }
   uint64_t get_tstamp(int32_t lev) const {
-    if (dec_level() < lev) return std::numeric_limits<uint32_t>::max();
+    if (dec_level() < lev) return std::numeric_limits<uint64_t>::max();
     return decisions[lev].tstamp;
   }
 

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -234,7 +234,7 @@ private:
   // Computing LBD (lbd == 2 means "glue clause")
   vector<uint64_t> lbd_helper;
   uint64_t lbd_helper_flag = 0;
-  template<class T2> uint32_t calc_lbd(const T2& lits);
+  template<class T2> uint8_t calc_lbd(const T2& lits);
 
   // Clause adding
   void simple_preprocess();
@@ -729,7 +729,7 @@ inline vector<Lit>::iterator Counter::top_declevel_trail_begin() {
 }
 
 template<class T2>
-uint32_t Counter::calc_lbd(const T2& lits) {
+uint8_t Counter::calc_lbd(const T2& lits) {
   lbd_helper_flag++;
   uint32_t nblevels = 0;
   for(const auto& l: lits) {

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -731,7 +731,7 @@ inline vector<Lit>::iterator Counter::top_declevel_trail_begin() {
 template<class T2>
 uint8_t Counter::calc_lbd(const T2& lits) {
   lbd_helper_flag++;
-  uint32_t nblevels = 0;
+  uint8_t nblevels = 0;
   for(const auto& l: lits) {
     if (val(l) == X_TRI) {nblevels++;continue;}
     int lev = var(l).decision_level;

--- a/src/flow-cutter-pace17/src/cell.hpp
+++ b/src/flow-cutter-pace17/src/cell.hpp
@@ -9,7 +9,7 @@ struct Cell{
 
 	int parent_cell;
 
-	int bag_size()const{
+	size_t bag_size()const{
 		return separator_node_list.size() + boundary_node_list.size();
 	}
 

--- a/src/stack.hpp
+++ b/src/stack.hpp
@@ -35,7 +35,7 @@ namespace GanakInt {
 
 class StackLevel {
 public:
-  StackLevel(uint32_t super_comp, uint32_t comp_stack_ofs, bool _is_indep, uint64_t _tstamp,
+  StackLevel(uint64_t super_comp, uint64_t comp_stack_ofs, bool _is_indep, uint64_t _tstamp,
       const FG& _fg) :
       fg(_fg),
       tstamp(_tstamp),
@@ -74,7 +74,7 @@ public:
 private:
 
   /// active Comp, once initialized, it does not change
-  const uint32_t super_comp_ = 0;
+  const uint64_t super_comp_ = 0;
 
   // branch (i.e. left = false/right = true)
   bool act_branch = false;
@@ -90,7 +90,7 @@ private:
   // all remaining comps can hence be found in
   // [remaining_comps_ofs_, "nextLevel".remaining_comps_begin_)
   // SET ONCE, NEVER TOUCHED
-  const uint32_t remaining_comps_ofs_ = 0;
+  const uint64_t remaining_comps_ofs_ = 0;
 
   // boundary of the stack marking which comps still need to be processed
   // all comps to be processed can be found in
@@ -98,14 +98,14 @@ private:
   // also, all processed, can be found
   // in [unprocessed_comps_end_, comp_stack.size())
   // KEEPS BEING DECREMENTED, until it reaches remaining_comps_ofs_
-  uint32_t unprocessed_comps_end_ = 0;
+  uint64_t unprocessed_comps_end_ = 0;
 
 public:
   bool has_unproc_comps() const {
     assert(unprocessed_comps_end_ >= remaining_comps_ofs_);
     return unprocessed_comps_end_ > remaining_comps_ofs_;
   }
-  uint32_t num_unproc_comps() const {
+  uint64_t num_unproc_comps() const {
     assert(unprocessed_comps_end_ >= remaining_comps_ofs_);
     return unprocessed_comps_end_ - remaining_comps_ofs_;
   }
@@ -115,16 +115,16 @@ public:
   }
   void reset_remain_comps() { unprocessed_comps_end_ = remaining_comps_ofs_; }
   auto get_unprocessed_comps_end() const { return unprocessed_comps_end_; }
-  uint32_t super_comp() const { return super_comp_; }
+  uint64_t super_comp() const { return super_comp_; }
   bool is_right_branch() const { return act_branch; }
-  uint32_t get_unproc_comps_end() const { return unprocessed_comps_end_; }
-  uint32_t remaining_comps_ofs() const { return remaining_comps_ofs_; }
-  void set_unprocessed_comps_end(uint32_t end) {
+  uint64_t get_unproc_comps_end() const { return unprocessed_comps_end_; }
+  uint64_t remaining_comps_ofs() const { return remaining_comps_ofs_; }
+  void set_unprocessed_comps_end(uint64_t end) {
     unprocessed_comps_end_ = end;
     assert(remaining_comps_ofs_ <= unprocessed_comps_end_);
   }
 
-  uint32_t curr_remain_comp() const {
+  uint64_t curr_remain_comp() const {
     assert(remaining_comps_ofs_ <= unprocessed_comps_end_ - 1);
     return unprocessed_comps_end_ - 1;
   }

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -185,7 +185,7 @@ public:
 
   double cache_miss_rate() const {
     if(num_cache_look_ups == 0) return 0.0;
-    return (num_cache_look_ups - num_cache_hits)
+    return (double)(num_cache_look_ups - num_cache_hits)
         / (double) num_cache_look_ups;
   }
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -153,14 +153,14 @@ public:
            + sum_extra_bytes;
   }
 
-  void incorporate_cache_store(const uint32_t& extra_bytes, const uint32_t comp_nvars) {
+  void incorporate_cache_store(const uint64_t& extra_bytes, const uint32_t comp_nvars) {
     sum_extra_bytes += extra_bytes;
     sum_cache_store_sizes += comp_nvars;
     num_cached_comps++;
     total_num_cached_comps++;
   }
 
-  void incorporate_cache_erase(const uint32_t extra_bytes){
+  void incorporate_cache_erase(const uint64_t extra_bytes){
     sum_extra_bytes -= extra_bytes;
     num_cached_comps--;
   }

--- a/src/structures.hpp
+++ b/src/structures.hpp
@@ -214,7 +214,7 @@ public:
   auto size() const { return sz; }
   void resize(const uint32_t sz2) {sz = sz2;}
   void update_lbd(uint32_t _lbd) {
-    if (_lbd > 250) return;
+    if (_lbd > 100) return;
     if (_lbd < lbd) lbd = _lbd;
   }
   Lit* data() const {

--- a/src/time_mem.hpp
+++ b/src/time_mem.hpp
@@ -25,13 +25,11 @@ THE SOFTWARE.
 
 #include <cassert>
 #include <functional>
-#include <ctime>
 
 #include <iostream>
 #include <fstream>
 #include <algorithm>
 #include <string>
-#include <csignal>
 #include <cstdint>
 
 // note: MinGW64 defines both __MINGW32__ and __MINGW64__
@@ -130,7 +128,7 @@ static inline uint64_t mem_used(double& vm_usage, std::string* max_mem_usage = n
    stat_stream.close();
 
    long page_size_kb = sysconf(_SC_PAGE_SIZE); // in case x86-64 is configured to use 2MB pages
-   vm_usage     = vsize;
+   vm_usage     = (double)vsize;
    double resident_set = (double)rss * (double)page_size_kb;
 
    if (max_mem_usage != nullptr) {
@@ -156,7 +154,7 @@ static inline uint64_t mem_used(double& vm_usage, std::string* max_mem_usage = n
       }
    }
 
-   return resident_set;
+   return (uint64_t)resident_set;
 }
 #elif defined(__FreeBSD__)
 #include <sys/types.h>


### PR DESCRIPTION
As kindly initiated by [Illner](https://github.com/Illner) via #58 . This seems to fix the issue:

c o Ganak SHA1: a8904ced6ebb85c8d131e675cd88a4fb18cbfd48
c o Arjun SHA1: 58ec9aff687c9adcd6a26f158a947c07794e43f6
c o SBVA SHA1: 0faa08cf3cc26ed855831c9dc16a3489c9ae010f
c o CMS SHA1: b09bd6bf05253adf5981e44f9dbd374b2811ff94
c o ApproxMC SHA1: 56042dc9002dee312bb4be283d2bdf8bc2a67827
c o CadiBack a35c4b98b6237b16ca0fd08dded8f8f51ff998a8
c o CaDiCaL 81de5d2b5c68727b4d183ec5ceb56561f1b3b6e1

The output is now:
```
./ganak stuff/issue_mc2025_track1_045/mc2025_track1_045.cnf
[...]
c o cache K (lookup/ stores/ hits/ dels) 4086852 1442456 2644395 1420938  -- Klookup/s:  1343.47
[...]
c o Total time [Arjun+GANAK]: 3042.77
s SATISFIABLE
c s type mc
c s log10-estimate 1.41236925e+01
c s exact arb int 132951278067432
c s pac guarantees epsilon: 0 delta: 7.43394103e-03
```
This seems to have slightly less components (old one was 4290630K).

With `--td 0` we get a MUCH faster count:
```
./ganak --td 0 stuff/issue_mc2025_track1_045/mc2025_track1_045.cnf | tee out2.txt
[...]
c o cache K (lookup/ stores/ hits/ dels) 2005855 626879 1378975 604360  -- Klookup/s:  1387.52
[...]
c o Total time [Arjun+GANAK]: 1446.50
s SATISFIABLE
c s type mc
c s log10-estimate 1.41236925e+01
c s exact arb int 132951278067432
c s pac guarantees epsilon: 0 delta: 3.64863023e-03
```

Notice that the count is good, even though the delta is kinda high (3 in 1000 chance of wrong count)